### PR TITLE
Align home tree ending with CTA

### DIFF
--- a/assets/js/TechTree.js
+++ b/assets/js/TechTree.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', function() {
   container.style.position = 'relative';
   container.style.width = '100%';
   container.style.margin = '1rem 0 0';
-  container.style.paddingBottom = '4rem';
+  container.style.paddingBottom = '0';
   container.style.pointerEvents = 'none';
   container.style.overflow = 'visible';
   
@@ -40,8 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
   const trunkLength = trunkBottom - 5;
   const viewBoxHeight = trunkBottom + 5; // Extra padding at bottom
 
-  // Set a min-height that scales with the tree
-  container.style.minHeight = `${viewBoxHeight * 1.1}vh`;
+  // Set a height that matches the tree
+  container.style.height = `${viewBoxHeight}vh`;
 
   // Create SVG element with dynamic viewBox
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');

--- a/index.html
+++ b/index.html
@@ -86,10 +86,9 @@
     
     /* CTA near the end of the tree */
     .cta-wrap {
-      position: fixed;
-      bottom: 40px;
-      left: 0;
-      right: 0;
+      display: flex;
+      justify-content: center;
+      margin-top: 2rem;
     }
     .cta-hire {
       display: inline-block; 


### PR DESCRIPTION
## Summary
- Remove extra height from home page tech tree so scrolling stops once the tree is complete
- Replace fixed CTA with centered "Hire me" button linking to contact page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bd832134832da8b377a62d920cd2