### PR TITLE
Add digital art service page with remote background

### DIFF
--- a/services/digital-art/index.html
+++ b/services/digital-art/index.html
@@ -1,0 +1,260 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Digital Art — Stay Real</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../assets/css/styles.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'Outfit', sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background-color: #ffffff;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 20px;
+    }
+
+    /* Hero Section */
+    .hero {
+      padding: 60px 0;
+      text-align: center;
+      background-image: url('https://images.unsplash.com/photo-1541420801058-9bdb9e5034e1?auto=format&fit=crop&w=1200&h=800&q=80');
+      background-size: cover;
+      background-position: center;
+      background-repeat: no-repeat;
+      color: #ffffff;
+    }
+
+    .hero h1 {
+      font-size: 48px;
+      font-weight: 300;
+      margin-bottom: 20px;
+      letter-spacing: -1px;
+    }
+
+    .hero-subtitle {
+      font-size: 20px;
+      color: #f0f0f0;
+      margin-bottom: 50px;
+      font-weight: 300;
+    }
+
+    /* Image Gallery */
+    .image-gallery {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      margin-bottom: 60px;
+      flex-wrap: wrap;
+    }
+
+    .gallery-item {
+      width: 300px;
+      height: 200px;
+      overflow: hidden;
+      border-radius: 8px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+      background: #f0f0f0;
+    }
+
+    /* Section Titles */
+    .section-title {
+      text-align: center;
+      font-size: 36px;
+      font-weight: 300;
+      color: #2c3e50;
+      margin-bottom: 60px;
+    }
+
+    /* CTA Section */
+    .cta {
+      padding: 80px 0;
+      text-align: center;
+    }
+
+    .cta h2 {
+      font-size: 36px;
+      font-weight: 300;
+      color: #2c3e50;
+      margin-bottom: 20px;
+    }
+
+    .cta p {
+      font-size: 18px;
+      color: #7f8c8d;
+      margin-bottom: 40px;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 15px 40px;
+      background: #3498db;
+      color: white;
+      text-decoration: none;
+      border-radius: 5px;
+      font-weight: 500;
+      transition: background 0.3s ease;
+    }
+
+    .btn:hover {
+      background: #2980b9;
+    }
+
+    footer {
+      background: #2c3e50;
+      color: white;
+      text-align: center;
+      padding: 40px 0;
+    }
+
+    @media (max-width: 768px) {
+      .hero h1 {
+        font-size: 36px;
+      }
+
+      .hero-subtitle {
+        font-size: 18px;
+      }
+
+      .image-gallery {
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .gallery-item {
+        width: 100%;
+        max-width: 400px;
+      }
+    }
+
+    /* Back button */
+    .back-button {
+      display: inline-block;
+      margin: 20px 0 0 16px;
+      color: #666;
+      text-decoration: none;
+      font-size: 14px;
+      transition: color 0.2s ease;
+    }
+
+    .back-button:hover {
+      color: #111;
+    }
+
+    .back-button::before {
+      content: "← ";
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="../../services/" class="back-button">Back to Services</a>
+    <nav class="nav">
+      <a class="pill" href="../../">Home</a>
+      <a class="pill" href="../../projects/">Projects</a>
+      <a class="pill active" href="../../services/">Services</a>
+      <a class="pill" href="../../contact/">Contact</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container">
+        <h1>Digital Art Excellence</h1>
+        <p class="hero-subtitle">Transforming ideas into visual masterpieces</p>
+        <div class="image-gallery">
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="diversity">
+      <div class="container">
+        <h2 class="section-title">DIVERSITY</h2>
+        <div class="image-gallery">
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="options">
+      <div class="container">
+        <h2 class="section-title">OPTIONS</h2>
+        <div class="image-gallery">
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="aesthetics">
+      <div class="container">
+        <h2 class="section-title">AESTHETICS</h2>
+        <div class="image-gallery">
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+          <div class="gallery-item"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="container">
+        <h2>Ready to Elevate Your Visuals?</h2>
+        <p>Let's collaborate to create art that resonates.</p>
+        <a href="../../contact/" class="btn">Get Started Today</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>&copy; 2025 Stay Real. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script>
+    // Smooth scrolling for navigation links
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+      anchor.addEventListener('click', function (e) {
+        e.preventDefault();
+        const target = document.querySelector(this.getAttribute('href'));
+        if (target) {
+          target.scrollIntoView({
+            behavior: 'smooth',
+            block: 'start'
+          });
+        }
+      });
+    });
+
+    // Add subtle parallax effect to gallery items
+    window.addEventListener('scroll', () => {
+      const scrolled = window.pageYOffset;
+      const galleryItems = document.querySelectorAll('.gallery-item');
+      galleryItems.forEach((item, index) => {
+        const speed = 0.1 + (index * 0.05);
+        item.style.transform = `translateY(${scrolled * speed}px)`;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/services/index.html
+++ b/services/index.html
@@ -159,6 +159,16 @@
         </div>
       </div>
     </a>
+    <a href="digital-art/" class="service-link">
+      <div class="service-column">
+        <img src="https://images.unsplash.com/photo-1541420801058-9bdb9e5034e1?auto=format&fit=crop&w=1200&h=800&q=80" alt="Digital art">
+        <div class="service-title-initial">Digital Art</div>
+        <div class="service-content">
+          <h2>Digital Art</h2>
+          <p>Custom digital artworks tailored to your vision.</p>
+        </div>
+      </div>
+    </a>
     <div class="service-column">
       <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&h=800&q=80" alt="Personalized automations">
       <div class="service-title-initial">Personalized Automations</div>


### PR DESCRIPTION
## Summary
- replace local digital art hero background with hosted image
- link digital art from services index without bundling binary assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bd013b40832da9cc8939f2261cf6