### PR TITLE
Fix project buttons becoming unclickable after modal

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -432,6 +432,7 @@
     buttonLabels.forEach((label, i) => {
       const btn = document.createElement('button');
       btn.className = 'skill-button'; btn.textContent = label;
+      if (transformTriggered) btn.classList.add('visible');
       document.body.appendChild(btn);
       const angle = i * angleStep - Math.PI/2;
       const x = CX + Math.cos(angle) * radius;


### PR DESCRIPTION
## Summary
- Ensure recreated project buttons remain visible and interactive after closing a modal.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7b7ff2c832db341703fd0886753