### PR TITLE
Align service card styling with Digital Marketing card

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -159,22 +159,22 @@
         <p>We craft data-driven strategies to boost your online presence, engage your audience, and drive conversions.</p>
       </div>
     </a>
-    <div class="service-column">
+    <a href="#" class="service-column">
       <img src="../assets/img/automations.png" alt="Personalized automations">
       <div class="service-title-initial">Personalized Automations</div>
       <div class="service-content">
         <h2>Personalized Automations</h2>
         <p>Streamline your workflows and increase efficiency with custom automations tailored to your business needs.</p>
       </div>
-    </div>
-    <div class="service-column">
+    </a>
+    <a href="#" class="service-column">
       <img src="../assets/img/coaching.png" alt="Personal Coaching">
       <div class="service-title-initial">Personal Coaching</div>
       <div class="service-content">
         <h2>Personal Coaching</h2>
         <p>Unlock your full potential with one-on-one coaching sessions designed to help you achieve your personal and professional goals.</p>
       </div>
-    </div>
+    </a>
   </main>
   <footer>
     © <span id="year"></span> Alex Shvachko — Stay Real.


### PR DESCRIPTION
## Summary
- Wrap "Personalized Automations" and "Personal Coaching" service cards with anchor tags so they match the Digital Marketing card's font, underline, and link styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aee8036834832db58e018e82a06fec